### PR TITLE
Add starter Flutter Planner app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'models/routine.dart';
+import 'views/calendar_page.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  Hive.registerAdapter(RoutineAdapter());
+  await Hive.openBox<Routine>('routines');
+
+  runApp(const PlannerApp());
+}
+
+class PlannerApp extends StatelessWidget {
+  const PlannerApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Planner',
+      themeMode: ThemeMode.system,
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        brightness: Brightness.light,
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.blue,
+          brightness: Brightness.dark,
+        ),
+        brightness: Brightness.dark,
+      ),
+      home: const CalendarPage(),
+    );
+  }
+}

--- a/lib/models/routine.dart
+++ b/lib/models/routine.dart
@@ -1,0 +1,37 @@
+import 'package:hive/hive.dart';
+
+
+@HiveType(typeId: 0)
+class Routine extends HiveObject {
+  @HiveField(0)
+  String title;
+
+  @HiveField(1)
+  DateTime date;
+
+  @HiveField(2)
+  bool isCompleted;
+
+  Routine({required this.title, required this.date, this.isCompleted = false});
+}
+
+class RoutineAdapter extends TypeAdapter<Routine> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Routine read(BinaryReader reader) {
+    return Routine(
+      title: reader.readString(),
+      date: DateTime.fromMillisecondsSinceEpoch(reader.readInt()),
+      isCompleted: reader.readBool(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Routine obj) {
+    writer.writeString(obj.title);
+    writer.writeInt(obj.date.millisecondsSinceEpoch);
+    writer.writeBool(obj.isCompleted);
+  }
+}

--- a/lib/services/routine_service.dart
+++ b/lib/services/routine_service.dart
@@ -1,0 +1,31 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/routine.dart';
+
+class RoutineService {
+  static const String boxName = 'routines';
+
+  Future<Box<Routine>> _openBox() async {
+    if (Hive.isBoxOpen(boxName)) {
+      return Hive.box<Routine>(boxName);
+    }
+    return await Hive.openBox<Routine>(boxName);
+  }
+
+  Future<List<Routine>> getRoutinesForDay(DateTime day) async {
+    final box = await _openBox();
+    final start = DateTime(day.year, day.month, day.day);
+    final end = DateTime(day.year, day.month, day.day, 23, 59, 59);
+    return box.values
+        .where((r) => r.date.isAfter(start.subtract(const Duration(seconds: 1))) && r.date.isBefore(end.add(const Duration(seconds: 1))))
+        .toList();
+  }
+
+  Future<void> addRoutine(Routine routine) async {
+    final box = await _openBox();
+    await box.add(routine);
+  }
+
+  Future<void> updateRoutine(Routine routine) async {
+    await routine.save();
+  }
+}

--- a/lib/views/calendar_page.dart
+++ b/lib/views/calendar_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:table_calendar/table_calendar.dart';
+import '../models/routine.dart';
+import '../services/routine_service.dart';
+
+class CalendarPage extends StatefulWidget {
+  const CalendarPage({super.key});
+
+  @override
+  State<CalendarPage> createState() => _CalendarPageState();
+}
+
+class _CalendarPageState extends State<CalendarPage> {
+  final RoutineService _service = RoutineService();
+  DateTime _focusedDay = DateTime.now();
+  DateTime? _selectedDay;
+  List<Routine> _routines = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDay = DateTime.now();
+    _loadRoutines();
+  }
+
+  Future<void> _loadRoutines() async {
+    if (_selectedDay == null) return;
+    final routines = await _service.getRoutinesForDay(_selectedDay!);
+    setState(() {
+      _routines = routines;
+    });
+  }
+
+  Future<void> _addRoutine() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Routine'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Title'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+    if (result != null && result.isNotEmpty) {
+      final routine = Routine(title: result, date: _selectedDay!);
+      await _service.addRoutine(routine);
+      _loadRoutines();
+    }
+  }
+
+  Widget _buildRoutineItem(Routine routine) {
+    return CheckboxListTile(
+      title: Text(routine.title),
+      value: routine.isCompleted,
+      onChanged: (value) async {
+        routine.isCompleted = value ?? false;
+        await _service.updateRoutine(routine);
+        _loadRoutines();
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Planner')),
+      body: Column(
+        children: [
+          TableCalendar(
+            firstDay: DateTime.utc(2000, 1, 1),
+            lastDay: DateTime.utc(2100, 12, 31),
+            focusedDay: _focusedDay,
+            selectedDayPredicate: (day) =>
+                _selectedDay != null && isSameDay(day, _selectedDay),
+            onDaySelected: (selectedDay, focusedDay) {
+              setState(() {
+                _selectedDay = selectedDay;
+                _focusedDay = focusedDay;
+              });
+              _loadRoutines();
+            },
+          ),
+          Expanded(
+            child: ListView(
+              children: _routines.map(_buildRoutineItem).toList(),
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addRoutine,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: planner
+description: A starter Flutter Planner application.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.8
+  table_calendar: ^3.0.9
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create starter Flutter app with a calendar and routines
- use Hive for local storage
- add light/dark Material 3 themes

## Testing
- `dart format lib pubspec.yaml` *(fails: `dart: command not found`)*
- `flutter --version` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856d85af0b483319a59de13de784086