### PR TITLE
Add task and routine models with navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'models/task.dart';
 import 'models/routine.dart';
 import 'views/calendar_page.dart';
+import 'views/routine_page.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
+  Hive.registerAdapter(TaskAdapter());
   Hive.registerAdapter(RoutineAdapter());
+  await Hive.openBox<Task>('tasks');
   await Hive.openBox<Routine>('routines');
 
   runApp(const PlannerApp());
@@ -33,7 +37,37 @@ class PlannerApp extends StatelessWidget {
         ),
         brightness: Brightness.dark,
       ),
-      home: const CalendarPage(),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
+  final List<Widget> _pages = const [CalendarPage(), RoutinePage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _index,
+        children: _pages,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _index,
+        onDestinationSelected: (i) => setState(() => _index = i),
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.calendar_today), label: 'Calendar'),
+          NavigationDestination(icon: Icon(Icons.repeat), label: 'Routines'),
+        ],
+      ),
     );
   }
 }

--- a/lib/models/routine.dart
+++ b/lib/models/routine.dart
@@ -1,37 +1,56 @@
+import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
-
-@HiveType(typeId: 0)
+@HiveType(typeId: 1)
 class Routine extends HiveObject {
   @HiveField(0)
   String title;
 
   @HiveField(1)
-  DateTime date;
+  List<int> weekdays;
 
   @HiveField(2)
-  bool isCompleted;
+  int? timeMinutes;
 
-  Routine({required this.title, required this.date, this.isCompleted = false});
+  @HiveField(3)
+  bool isActive;
+
+  Routine({
+    required this.title,
+    required this.weekdays,
+    this.timeMinutes,
+    this.isActive = true,
+  });
+
+  TimeOfDay? get time =>
+      timeMinutes == null ? null : TimeOfDay(hour: timeMinutes! ~/ 60, minute: timeMinutes! % 60);
+  set time(TimeOfDay? t) => timeMinutes = t == null ? null : t.hour * 60 + t.minute;
 }
 
 class RoutineAdapter extends TypeAdapter<Routine> {
   @override
-  final int typeId = 0;
+  final int typeId = 1;
 
   @override
   Routine read(BinaryReader reader) {
     return Routine(
       title: reader.readString(),
-      date: DateTime.fromMillisecondsSinceEpoch(reader.readInt()),
-      isCompleted: reader.readBool(),
+      weekdays: List<int>.from(reader.readList()),
+      timeMinutes: reader.readBool() ? reader.readInt() : null,
+      isActive: reader.readBool(),
     );
   }
 
   @override
   void write(BinaryWriter writer, Routine obj) {
     writer.writeString(obj.title);
-    writer.writeInt(obj.date.millisecondsSinceEpoch);
-    writer.writeBool(obj.isCompleted);
+    writer.writeList(obj.weekdays);
+    if (obj.timeMinutes != null) {
+      writer.writeBool(true);
+      writer.writeInt(obj.timeMinutes!);
+    } else {
+      writer.writeBool(false);
+    }
+    writer.writeBool(obj.isActive);
   }
 }

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,36 @@
+import 'package:hive/hive.dart';
+
+@HiveType(typeId: 0)
+class Task extends HiveObject {
+  @HiveField(0)
+  String title;
+
+  @HiveField(1)
+  DateTime date;
+
+  @HiveField(2)
+  bool isCompleted;
+
+  Task({required this.title, required this.date, this.isCompleted = false});
+}
+
+class TaskAdapter extends TypeAdapter<Task> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Task read(BinaryReader reader) {
+    return Task(
+      title: reader.readString(),
+      date: DateTime.fromMillisecondsSinceEpoch(reader.readInt()),
+      isCompleted: reader.readBool(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Task obj) {
+    writer.writeString(obj.title);
+    writer.writeInt(obj.date.millisecondsSinceEpoch);
+    writer.writeBool(obj.isCompleted);
+  }
+}

--- a/lib/services/routine_service.dart
+++ b/lib/services/routine_service.dart
@@ -11,13 +11,9 @@ class RoutineService {
     return await Hive.openBox<Routine>(boxName);
   }
 
-  Future<List<Routine>> getRoutinesForDay(DateTime day) async {
+  Future<List<Routine>> getRoutines() async {
     final box = await _openBox();
-    final start = DateTime(day.year, day.month, day.day);
-    final end = DateTime(day.year, day.month, day.day, 23, 59, 59);
-    return box.values
-        .where((r) => r.date.isAfter(start.subtract(const Duration(seconds: 1))) && r.date.isBefore(end.add(const Duration(seconds: 1))))
-        .toList();
+    return box.values.toList();
   }
 
   Future<void> addRoutine(Routine routine) async {
@@ -27,5 +23,9 @@ class RoutineService {
 
   Future<void> updateRoutine(Routine routine) async {
     await routine.save();
+  }
+
+  Future<void> deleteRoutine(Routine routine) async {
+    await routine.delete();
   }
 }

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -1,0 +1,32 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/task.dart';
+
+class TaskService {
+  static const String boxName = 'tasks';
+
+  Future<Box<Task>> _openBox() async {
+    if (Hive.isBoxOpen(boxName)) {
+      return Hive.box<Task>(boxName);
+    }
+    return await Hive.openBox<Task>(boxName);
+  }
+
+  Future<List<Task>> getTasksForDay(DateTime day) async {
+    final box = await _openBox();
+    final start = DateTime(day.year, day.month, day.day);
+    final end = DateTime(day.year, day.month, day.day, 23, 59, 59);
+    return box.values
+        .where((t) => t.date.isAfter(start.subtract(const Duration(seconds: 1))) &&
+            t.date.isBefore(end.add(const Duration(seconds: 1))))
+        .toList();
+  }
+
+  Future<void> addTask(Task task) async {
+    final box = await _openBox();
+    await box.add(task);
+  }
+
+  Future<void> updateTask(Task task) async {
+    await task.save();
+  }
+}

--- a/lib/views/calendar_page.dart
+++ b/lib/views/calendar_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
-import '../models/routine.dart';
-import '../services/routine_service.dart';
+import '../models/task.dart';
+import '../services/task_service.dart';
 
 class CalendarPage extends StatefulWidget {
   const CalendarPage({super.key});
@@ -11,32 +11,32 @@ class CalendarPage extends StatefulWidget {
 }
 
 class _CalendarPageState extends State<CalendarPage> {
-  final RoutineService _service = RoutineService();
+  final TaskService _service = TaskService();
   DateTime _focusedDay = DateTime.now();
   DateTime? _selectedDay;
-  List<Routine> _routines = [];
+  List<Task> _tasks = [];
 
   @override
   void initState() {
     super.initState();
     _selectedDay = DateTime.now();
-    _loadRoutines();
+    _loadTasks();
   }
 
-  Future<void> _loadRoutines() async {
+  Future<void> _loadTasks() async {
     if (_selectedDay == null) return;
-    final routines = await _service.getRoutinesForDay(_selectedDay!);
+    final tasks = await _service.getTasksForDay(_selectedDay!);
     setState(() {
-      _routines = routines;
+      _tasks = tasks;
     });
   }
 
-  Future<void> _addRoutine() async {
+  Future<void> _addTask() async {
     final controller = TextEditingController();
     final result = await showDialog<String>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('New Routine'),
+        title: const Text('New Task'),
         content: TextField(
           controller: controller,
           decoration: const InputDecoration(labelText: 'Title'),
@@ -54,20 +54,20 @@ class _CalendarPageState extends State<CalendarPage> {
       ),
     );
     if (result != null && result.isNotEmpty) {
-      final routine = Routine(title: result, date: _selectedDay!);
-      await _service.addRoutine(routine);
-      _loadRoutines();
+      final task = Task(title: result, date: _selectedDay!);
+      await _service.addTask(task);
+      _loadTasks();
     }
   }
 
-  Widget _buildRoutineItem(Routine routine) {
+  Widget _buildTaskItem(Task task) {
     return CheckboxListTile(
-      title: Text(routine.title),
-      value: routine.isCompleted,
+      title: Text(task.title),
+      value: task.isCompleted,
       onChanged: (value) async {
-        routine.isCompleted = value ?? false;
-        await _service.updateRoutine(routine);
-        _loadRoutines();
+        task.isCompleted = value ?? false;
+        await _service.updateTask(task);
+        _loadTasks();
       },
     );
   }
@@ -89,18 +89,18 @@ class _CalendarPageState extends State<CalendarPage> {
                 _selectedDay = selectedDay;
                 _focusedDay = focusedDay;
               });
-              _loadRoutines();
+              _loadTasks();
             },
           ),
           Expanded(
             child: ListView(
-              children: _routines.map(_buildRoutineItem).toList(),
+              children: _tasks.map(_buildTaskItem).toList(),
             ),
           ),
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: _addRoutine,
+        onPressed: _addTask,
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/views/routine_page.dart
+++ b/lib/views/routine_page.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../models/routine.dart';
+import '../services/routine_service.dart';
+
+class RoutinePage extends StatefulWidget {
+  const RoutinePage({super.key});
+
+  @override
+  State<RoutinePage> createState() => _RoutinePageState();
+}
+
+class _RoutinePageState extends State<RoutinePage> {
+  final RoutineService _service = RoutineService();
+  List<Routine> _routines = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final routines = await _service.getRoutines();
+    setState(() {
+      _routines = routines;
+    });
+  }
+
+  Future<void> _addRoutine() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Routine'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Title'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context, controller.text), child: const Text('Add')),
+        ],
+      ),
+    );
+    if (result != null && result.isNotEmpty) {
+      final r = Routine(title: result, weekdays: [], isActive: true);
+      await _service.addRoutine(r);
+      _load();
+    }
+  }
+
+  Widget _buildWeekdayCheckbox(Routine routine, int day) {
+    return Expanded(
+      child: CheckboxListTile(
+        dense: true,
+        title: Text(['Mon','Tue','Wed','Thu','Fri','Sat','Sun'][day-1], style: const TextStyle(fontSize: 12)),
+        value: routine.weekdays.contains(day),
+        onChanged: (val) async {
+          if (val == true) {
+            routine.weekdays.add(day);
+          } else {
+            routine.weekdays.remove(day);
+          }
+          await _service.updateRoutine(routine);
+          setState(() {});
+        },
+      ),
+    );
+  }
+
+  Widget _buildRoutineItem(Routine routine) {
+    return Card(
+      child: Column(
+        children: [
+          ListTile(
+            title: Text(routine.title),
+            trailing: Switch(
+              value: routine.isActive,
+              onChanged: (val) async {
+                routine.isActive = val;
+                await _service.updateRoutine(routine);
+                setState(() {});
+              },
+            ),
+            onLongPress: () async {
+              await _service.deleteRoutine(routine);
+              _load();
+            },
+          ),
+          Row(
+            children: List.generate(7, (index) => _buildWeekdayCheckbox(routine, index + 1)),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Routines')),
+      body: ListView(
+        children: _routines.map(_buildRoutineItem).toList(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addRoutine,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- rename Routine to Task
- add new Routine model for repeating tasks
- add services for tasks and routines
- create Routine page and update Calendar page
- introduce bottom navigation in main.dart

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856dfe8a1e083319732554da90e8ce0