### PR TITLE
Add full routines system

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
   Hive.registerAdapter(TaskAdapter());
+  Hive.registerAdapter(RepeatTypeAdapter());
   Hive.registerAdapter(RoutineAdapter());
   await Hive.openBox<Task>('tasks');
   await Hive.openBox<Routine>('routines');

--- a/lib/models/routine.dart
+++ b/lib/models/routine.dart
@@ -1,22 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
+enum RepeatType { daily, weekly, custom }
+
+class RepeatTypeAdapter extends TypeAdapter<RepeatType> {
+  @override
+  final int typeId = 2;
+
+  @override
+  RepeatType read(BinaryReader reader) {
+    return RepeatType.values[reader.readInt()];
+  }
+
+  @override
+  void write(BinaryWriter writer, RepeatType obj) {
+    writer.writeInt(obj.index);
+  }
+}
+
 @HiveType(typeId: 1)
 class Routine extends HiveObject {
   @HiveField(0)
   String title;
 
   @HiveField(1)
-  List<int> weekdays;
+  RepeatType repeatType;
 
   @HiveField(2)
-  int? timeMinutes;
+  List<int> weekdays;
 
   @HiveField(3)
+  int? timeMinutes;
+
+  @HiveField(4)
   bool isActive;
 
   Routine({
     required this.title,
+    required this.repeatType,
     required this.weekdays,
     this.timeMinutes,
     this.isActive = true,
@@ -35,6 +56,7 @@ class RoutineAdapter extends TypeAdapter<Routine> {
   Routine read(BinaryReader reader) {
     return Routine(
       title: reader.readString(),
+      repeatType: RepeatType.values[reader.readInt()],
       weekdays: List<int>.from(reader.readList()),
       timeMinutes: reader.readBool() ? reader.readInt() : null,
       isActive: reader.readBool(),
@@ -44,6 +66,7 @@ class RoutineAdapter extends TypeAdapter<Routine> {
   @override
   void write(BinaryWriter writer, Routine obj) {
     writer.writeString(obj.title);
+    writer.writeInt(obj.repeatType.index);
     writer.writeList(obj.weekdays);
     if (obj.timeMinutes != null) {
       writer.writeBool(true);


### PR DESCRIPTION
## Summary
- add `RepeatType` enum and adapter for routines
- support new routine fields in `Routine` model
- register adapter in `main`
- redesign routines page with add/edit/delete functionality

## Testing
- `dart` command not found; unable to run formatter or analyzer

------
https://chatgpt.com/codex/tasks/task_e_6856ea9c4a8883319ef5cf569bd6409b