### PR TITLE
Fix notification scheduling

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -15,7 +15,7 @@ class NotificationService {
     if (task.reminderMinutes == null) return;
     final date = DateTime(task.date.year, task.date.month, task.date.day)
         .add(Duration(minutes: task.reminderMinutes!));
-    await _plugin.zonedSchedule(
+    await _plugin.schedule(
       task.key as int? ?? 0,
       task.title,
       '',
@@ -25,7 +25,8 @@ class NotificationService {
         iOS: IOSNotificationDetails(),
       ),
       androidAllowWhileIdle: true,
-      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
       matchDateTimeComponents: DateTimeComponents.time,
     );
   }


### PR DESCRIPTION
## Summary
- use schedule instead of zonedSchedule for notifications

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5b1dfb48331be80553f0a943196