### PR TITLE
Fix Hive box typing and integration test imports

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:planner/main.dart' as app;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ Future<void> main() async {
   Hive.registerAdapter(RoutineAdapter());
   await Hive.openBox<Task>('tasks');
   await Hive.openBox<Routine>('routines');
-  await Hive.openBox<Map>('routine_done');
+  await Hive.openBox<List>('routine_done');
   await Hive.openBox('settings');
   await NotificationService().init();
 

--- a/lib/services/routine_service.dart
+++ b/lib/services/routine_service.dart
@@ -14,11 +14,11 @@ class RoutineService implements IRoutineService {
     return await Hive.openBox<Routine>(boxName);
   }
 
-  Future<Box<Map>> _openCompletionBox() async {
+  Future<Box<List>> _openCompletionBox() async {
     if (Hive.isBoxOpen(completionBox)) {
-      return Hive.box<Map>(completionBox);
+      return Hive.box<List>(completionBox);
     }
-    return await Hive.openBox<Map>(completionBox);
+    return await Hive.openBox<List>(completionBox);
   }
 
   Future<List<Routine>> getRoutines() async {


### PR DESCRIPTION
## Summary
- correct the Hive box type for routine completion tracking
- fix integration test by importing Material library

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bc8ef9224833192ff49ce23765289