### PR TITLE
Enhance routines UI, timers, stats

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -36,6 +36,34 @@ class NotificationService {
     );
   }
 
+  int _routineId(String routineKey, DateTime date) {
+    final day = DateTime(date.year, date.month, date.day).millisecondsSinceEpoch;
+    return routineKey.hashCode ^ day.hashCode;
+  }
+
+  Future<void> scheduleRoutineTimerNotification(
+      Routine r, DateTime dateOccur, Duration duration) async {
+    final target = tz.TZDateTime.from(dateOccur.add(duration), tz.local);
+    await _plugin.zonedSchedule(
+      _routineId(r.key.toString(), dateOccur),
+      r.title,
+      'Timer complete',
+      target,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('routines', 'Routines'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<void> cancelRoutineNotification(String routineKey, DateTime dateOccur) async {
+    await _plugin.cancel(_routineId(routineKey, dateOccur));
+  }
+
   Future<void> scheduleRoutineReminder(Routine r, DateTime nextOccur) async {}
 
   Future<void> cancelRoutineReminder(String routineKey) async {}

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -13,6 +13,8 @@ class StatsService extends ChangeNotifier {
   late final ValueListenable _completionListenable;
 
   Map<DateTime, double> weekly = {};
+  Map<DateTime, int> tasksCompleted = {};
+  Map<DateTime, int> minutesSpent = {};
   Map<Routine, String> routineStats = {};
   int completedToday = 0;
   Duration timeSpentToday = Duration.zero;
@@ -50,6 +52,8 @@ class StatsService extends ChangeNotifier {
     final Map<Routine, int> doneCounts = {for (var r in routines) r: 0};
     final Map<Routine, int> totalCounts = {for (var r in routines) r: 0};
     final Map<DateTime, double> completion = {};
+    final Map<DateTime, int> taskCounts = {};
+    final Map<DateTime, int> minuteCounts = {};
 
     completedToday = 0;
     timeSpentToday = Duration.zero;
@@ -63,6 +67,8 @@ class StatsService extends ChangeNotifier {
 
       int total = tasks.length + dayRoutines.length;
       int done = tasks.where((t) => t.isCompleted).length;
+      int minutes = 0;
+      final completedTasks = tasks.where((t) => t.isCompleted).length;
 
       for (final r in dayRoutines) {
         final d = _routineDone(r, day);
@@ -75,6 +81,9 @@ class StatsService extends ChangeNotifier {
               timeSpentToday += r.duration!;
             }
           }
+          if (r.duration != null) {
+            minutes += r.duration!.inMinutes;
+          }
         }
         if (r.weekdays.contains(day.weekday)) {
           totalCounts[r] = totalCounts[r]! + 1;
@@ -82,13 +91,18 @@ class StatsService extends ChangeNotifier {
       }
 
       if (_sameDay(day, now)) {
-        completedToday += tasks.where((t) => t.isCompleted).length;
+        completedToday += completedTasks;
       }
+
+      taskCounts[day] = completedTasks;
+      minuteCounts[day] = minutes;
 
       completion[day] = total == 0 ? 0 : done / total * 100;
     }
 
     weekly = completion;
+    tasksCompleted = taskCounts;
+    minutesSpent = minuteCounts;
     routineStats = {
       for (var r in routines) r: '${doneCounts[r]}/${totalCounts[r]}'
     };

--- a/lib/views/calendar_page.dart
+++ b/lib/views/calendar_page.dart
@@ -197,17 +197,27 @@ class _CalendarPageState extends State<CalendarPage> {
         children: [
           Padding(
             padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('You have ${_tasks.length} tasks and $_routineCount routines today'),
-                const SizedBox(height: 4),
-                LinearProgressIndicator(
-                  value: _tasks.isEmpty
-                      ? 0
-                      : _tasks.where((t) => t.isCompleted).length / _tasks.length,
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Builder(
+                  builder: (context) {
+                    final total = _tasks.length + _routineCount;
+                    final completed =
+                        _tasks.where((t) => t.isCompleted).length +
+                            _routineDone.values.where((d) => d).length;
+                    final progress = total == 0 ? 0 : completed / total;
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Completed $completed of $total items today'),
+                        const SizedBox(height: 4),
+                        LinearProgressIndicator(value: progress),
+                      ],
+                    );
+                  },
                 ),
-              ],
+              ),
             ),
           ),
           Row(

--- a/lib/views/statistics_page.dart
+++ b/lib/views/statistics_page.dart
@@ -12,13 +12,6 @@ class StatisticsPage extends StatefulWidget {
 class _StatisticsPageState extends State<StatisticsPage> {
   late final StatsService _stats;
 
-  String _formatDuration(Duration d) {
-    final h = d.inHours;
-    final m = d.inMinutes.remainder(60);
-    if (h == 0) return '${m}m';
-    return '${h}h ${m}m';
-  }
-
   @override
   void initState() {
     super.initState();
@@ -47,8 +40,9 @@ class _StatisticsPageState extends State<StatisticsPage> {
                 trailing: Text('${_stats.completedToday}'),
               ),
               ListTile(
-                title: const Text('Time on Routines Today'),
-                trailing: Text(_formatDuration(_stats.timeSpentToday)),
+                title: const Text('Minutes Spent on Routines Today'),
+                trailing:
+                    Text('${_stats.timeSpentToday.inMinutes}m'),
               ),
               const SizedBox(height: 16),
               SizedBox(
@@ -72,6 +66,47 @@ class _StatisticsPageState extends State<StatisticsPage> {
                       final percent = weekly.values.elementAt(index);
                       return BarChartGroupData(x: index, barRods: [BarChartRodData(toY: percent)]);
                     }),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                height: 200,
+                child: LineChart(
+                  LineChartData(
+                    titlesData: FlTitlesData(
+                      bottomTitles: AxisTitles(
+                        sideTitles: SideTitles(
+                          showTitles: true,
+                          getTitlesWidget: (value, meta) {
+                            final date =
+                                _stats.minutesSpent.keys.elementAt(value.toInt());
+                            return Text('${date.month}/${date.day}',
+                                style: const TextStyle(fontSize: 10));
+                          },
+                        ),
+                      ),
+                    ),
+                    lineBarsData: [
+                      LineChartBarData(
+                        color: Colors.blue,
+                        spots: List.generate(
+                          _stats.tasksCompleted.length,
+                          (i) => FlSpot(
+                              i.toDouble(),
+                              _stats.tasksCompleted.values.elementAt(i).toDouble()),
+                        ),
+                      ),
+                      LineChartBarData(
+                        color: Colors.red,
+                        spots: List.generate(
+                          _stats.minutesSpent.length,
+                          (i) => FlSpot(
+                              i.toDouble(),
+                              _stats.minutesSpent.values.elementAt(i).toDouble()),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- allow unchecking routines and animate completed style
- add pause/resume/stop controls to routine timers with notifications
- show progress card on calendar page
- extend stats tracking and show line chart of activity
- schedule routine timer notifications

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf3e5c93c8331beb0c8e0302bc4cc