### PR TITLE
Update notification service and history page

### DIFF
--- a/lib/views/history_page.dart
+++ b/lib/views/history_page.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import '../models/task.dart';
-import '../models/routine.dart';
 import '../services/task_service.dart';
 import '../services/routine_service.dart';
 
@@ -100,22 +98,25 @@ class _HistoryPageState extends State<HistoryPage> {
             ],
           ),
           Expanded(
-            child: ListView(
-              children: _items.entries.map((e) {
-                final date = e.key;
-                final label = '${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'][date.weekday-1]} ${date.day} ${_month(date.month)}';
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
-                    ),
-                    ...e.value,
-                    const Divider(),
-                  ],
-                );
-              }).toList(),
+            child: RefreshIndicator(
+              onRefresh: _load,
+              child: ListView(
+                children: _items.entries.map((e) {
+                  final date = e.key;
+                  final label = _dateLabel(date);
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+                      ),
+                      ...e.value,
+                      const Divider(),
+                    ],
+                  );
+                }).toList(),
+              ),
             ),
           ),
         ],
@@ -124,4 +125,14 @@ class _HistoryPageState extends State<HistoryPage> {
   }
 
   String _month(int m) => ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][m-1];
+
+  String _dateLabel(DateTime d) {
+    final today = DateTime.now();
+    final day = DateTime(today.year, today.month, today.day);
+    final target = DateTime(d.year, d.month, d.day);
+    final diff = day.difference(target).inDays;
+    if (diff == 0) return 'Today';
+    if (diff == 1) return 'Yesterday';
+    return '${['Mon','Tue','Wed','Thu','Fri','Sat','Sun'][target.weekday-1]} ${target.day} ${_month(target.month)}';
+  }
 }

--- a/test/history_page_test.dart
+++ b/test/history_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:planner/models/task.dart';
+import 'package:planner/views/history_page.dart';
+import 'package:planner/services/task_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Hive.initFlutter();
+    Hive.registerAdapter(TaskAdapter());
+    await Hive.openBox<Task>('tasks');
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('tasks');
+  });
+
+  testWidgets('shows history entry', (tester) async {
+    final service = TaskService();
+    final task = Task(title: 'history test', date: DateTime.now(), isCompleted: true);
+    await service.addTask(task);
+
+    await tester.pumpWidget(const MaterialApp(home: HistoryPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('history test'), findsOneWidget);
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:planner/models/task.dart';
+import 'package:planner/services/notification_service.dart';
+
+void main() {
+  const MethodChannel channel = MethodChannel('dexterous.com/flutter_local_notifications');
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    channel.setMockMethodCallHandler((_) async {});
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  test('scheduleTaskReminder returns id', () async {
+    final service = NotificationService();
+    await service.init();
+    final task = Task(title: 't', date: DateTime.now(), reminderMinutes: 1);
+    final id = await service.scheduleTaskReminder(task);
+    expect(id, greaterThan(0));
+  });
+}


### PR DESCRIPTION
## Summary
- refactor NotificationService to singleton factory
- integrate TaskService and RoutineService singletons
- update scheduling APIs to use `androidScheduleMode`
- refreshable & searchable HistoryPage grouped by friendly dates
- add notification and history page tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a6723c8833186f1f293545f459a