### PR TITLE
Implement tag system and checkbox fixes

### DIFF
--- a/lib/models/routine.dart
+++ b/lib/models/routine.dart
@@ -38,6 +38,9 @@ class Routine extends HiveObject {
   @HiveField(5)
   int? durationMinutes;
 
+  @HiveField(6)
+  String? tagId;
+
   Routine({
     required this.title,
     required this.repeatType,
@@ -45,6 +48,7 @@ class Routine extends HiveObject {
     this.timeMinutes,
     this.isActive = true,
     this.durationMinutes,
+    this.tagId,
   });
 
   TimeOfDay? get time =>
@@ -68,6 +72,7 @@ class RoutineAdapter extends TypeAdapter<Routine> {
       timeMinutes: reader.readBool() ? reader.readInt() : null,
       isActive: reader.readBool(),
       durationMinutes: reader.readBool() ? reader.readInt() : null,
+      tagId: reader.readBool() ? reader.readString() : null,
     );
   }
 
@@ -86,6 +91,12 @@ class RoutineAdapter extends TypeAdapter<Routine> {
     if (obj.durationMinutes != null) {
       writer.writeBool(true);
       writer.writeInt(obj.durationMinutes!);
+    } else {
+      writer.writeBool(false);
+    }
+    if (obj.tagId != null) {
+      writer.writeBool(true);
+      writer.writeString(obj.tagId!);
     } else {
       writer.writeBool(false);
     }

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -18,6 +18,9 @@ class Task extends HiveObject {
   @HiveField(4)
   int? reminderMinutes;
 
+  @HiveField(5)
+  String? tagId;
+
   TimeOfDay? get reminderTime => reminderMinutes == null
       ? null
       : TimeOfDay(hour: reminderMinutes! ~/ 60, minute: reminderMinutes! % 60);
@@ -30,6 +33,7 @@ class Task extends HiveObject {
     this.isCompleted = false,
     this.tag,
     this.reminderMinutes,
+    this.tagId,
   });
 }
 
@@ -45,6 +49,7 @@ class TaskAdapter extends TypeAdapter<Task> {
       isCompleted: reader.readBool(),
       tag: reader.readBool() ? reader.readString() : null,
       reminderMinutes: reader.readBool() ? reader.readInt() : null,
+      tagId: reader.readBool() ? reader.readString() : null,
     );
   }
 
@@ -62,6 +67,12 @@ class TaskAdapter extends TypeAdapter<Task> {
     if (obj.reminderMinutes != null) {
       writer.writeBool(true);
       writer.writeInt(obj.reminderMinutes!);
+    } else {
+      writer.writeBool(false);
+    }
+    if (obj.tagId != null) {
+      writer.writeBool(true);
+      writer.writeString(obj.tagId!);
     } else {
       writer.writeBool(false);
     }

--- a/lib/services/i_routine_service.dart
+++ b/lib/services/i_routine_service.dart
@@ -2,10 +2,11 @@ import '../models/routine.dart';
 
 abstract class IRoutineService {
   Future<List<Routine>> getRoutines();
-  Future<List<Routine>> getRoutinesForDay(DateTime day);
+  Future<List<Routine>> getRoutinesForDay(DateTime day, {String? tagId});
   Future<void> addRoutine(Routine routine);
   Future<void> updateRoutine(Routine routine);
   Future<void> deleteRoutine(Routine routine);
+  Future<void> toggleComplete(Routine routine, DateTime day, bool done);
   Future<void> markCompleted(Routine routine, DateTime day, bool done);
   Future<bool> isCompleted(Routine routine, DateTime day);
 }

--- a/lib/services/i_task_service.dart
+++ b/lib/services/i_task_service.dart
@@ -1,7 +1,8 @@
 import "../models/task.dart";
 abstract class ITaskService {
-  Future<List<Task>> getTasksForDay(DateTime day, {String? tag});
+  Future<List<Task>> getTasksForDay(DateTime day, {String? tagId});
   Future<void> addTask(Task task);
   Future<void> updateTask(Task task);
   Future<void> deleteTask(Task task);
+  Future<void> toggleComplete(Task task, bool done);
 }

--- a/lib/services/routine_service.dart
+++ b/lib/services/routine_service.dart
@@ -117,11 +117,14 @@ class RoutineService implements IRoutineService {
     await trackStreak(routineKey, date, false);
   }
 
-  Future<List<Routine>> getRoutinesForDay(DateTime day) async {
+  Future<List<Routine>> getRoutinesForDay(DateTime day, {String? tagId}) async {
     final box = await _openBox();
     final weekday = day.weekday;
     return box.values
-        .where((r) => r.isActive && r.weekdays.contains(weekday))
+        .where((r) =>
+            r.isActive &&
+            r.weekdays.contains(weekday) &&
+            (tagId == null || r.tagId == tagId))
         .toList();
   }
 
@@ -141,6 +144,15 @@ class RoutineService implements IRoutineService {
   Future<void> deleteRoutine(Routine routine) async {
     await NotificationService().cancelRoutineReminder(routine.key.toString());
     await routine.delete();
+  }
+
+  Future<void> toggleComplete(
+      Routine routine, DateTime day, bool done) async {
+    if (done) {
+      await markRoutineDone(routine.key.toString(), day);
+    } else {
+      await unmarkRoutineDone(routine.key.toString(), day);
+    }
   }
 
   @override

--- a/lib/services/tag_service.dart
+++ b/lib/services/tag_service.dart
@@ -1,0 +1,70 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import '../models/tag.dart';
+import '../models/task.dart';
+import '../models/routine.dart';
+import 'task_service.dart';
+import 'routine_service.dart';
+
+class TagService {
+  static const String boxName = 'tags';
+
+  Future<Box<Tag>> _openBox() async {
+    if (Hive.isBoxOpen(boxName)) return Hive.box<Tag>(boxName);
+    return await Hive.openBox<Tag>(boxName);
+  }
+
+  Future<List<Tag>> getAllTags() async {
+    final box = await _openBox();
+    return box.values.toList();
+  }
+
+  Tag? getTagById(String id) {
+    final key = int.tryParse(id);
+    if (key == null) return null;
+    if (!Hive.isBoxOpen(boxName)) return null;
+    return Hive.box<Tag>(boxName).get(key);
+  }
+
+  Future<bool> addTag(Tag tag) async {
+    final box = await _openBox();
+    if (box.values.any((t) => t.name.toLowerCase() == tag.name.toLowerCase())) {
+      return false;
+    }
+    await box.add(tag);
+    return true;
+  }
+
+  Future<bool> updateTag(Tag tag) async {
+    final box = await _openBox();
+    if (box.values.any((t) => t.key != tag.key &&
+        t.name.toLowerCase() == tag.name.toLowerCase())) {
+      return false;
+    }
+    await tag.save();
+    return true;
+  }
+
+  Future<void> deleteTag(Tag tag) async {
+    final id = tag.key.toString();
+    await tag.delete();
+    await _cascadeDelete(id);
+  }
+
+  Future<void> _cascadeDelete(String tagId) async {
+    final taskBox = await Hive.openBox<Task>(TaskService.boxName);
+    for (final t in taskBox.values) {
+      if (t.tagId == tagId) {
+        t.tagId = null;
+        await t.save();
+      }
+    }
+
+    final routineBox = await Hive.openBox<Routine>(RoutineService.boxName);
+    for (final r in routineBox.values) {
+      if (r.tagId == tagId) {
+        r.tagId = null;
+        await r.save();
+      }
+    }
+  }
+}

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -12,14 +12,14 @@ class TaskService implements ITaskService {
     return await Hive.openBox<Task>(boxName);
   }
 
-  Future<List<Task>> getTasksForDay(DateTime day, {String? tag}) async {
+  Future<List<Task>> getTasksForDay(DateTime day, {String? tagId}) async {
     final box = await _openBox();
     final start = DateTime(day.year, day.month, day.day);
     final end = DateTime(day.year, day.month, day.day, 23, 59, 59);
     return box.values
         .where((t) => t.date.isAfter(start.subtract(const Duration(seconds: 1))) &&
             t.date.isBefore(end.add(const Duration(seconds: 1))) &&
-            (tag == null || t.tag == tag))
+            (tagId == null || t.tagId == tagId))
         .toList();
   }
 
@@ -29,6 +29,11 @@ class TaskService implements ITaskService {
   }
 
   Future<void> updateTask(Task task) async {
+    await task.save();
+  }
+
+  Future<void> toggleComplete(Task task, bool done) async {
+    task.isCompleted = done;
     await task.save();
   }
 

--- a/test/task_toggle_test.dart
+++ b/test/task_toggle_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:planner/models/task.dart';
+import 'package:planner/services/task_service.dart';
+import 'package:planner/widgets/task_tile.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Hive.initFlutter();
+    Hive.registerAdapter(TaskAdapter());
+    await Hive.openBox<Task>('tasks');
+  });
+
+  tearDown(() async {
+    final box = Hive.box<Task>('tasks');
+    await box.clear();
+    await box.close();
+  });
+
+  testWidgets('toggling one task does not affect others', (tester) async {
+    final service = TaskService();
+    final t1 = Task(title: 'A', date: DateTime(2020));
+    final t2 = Task(title: 'B', date: DateTime(2020));
+    await service.addTask(t1);
+    await service.addTask(t2);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: [
+          TaskTile(task: t1),
+          TaskTile(task: t2),
+        ],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Checkbox).first);
+    await tester.pumpAndSettle();
+    expect(t1.isCompleted, true);
+    expect(t2.isCompleted, false);
+
+    await tester.tap(find.byType(Checkbox).first);
+    await tester.pumpAndSettle();
+    expect(t1.isCompleted, false);
+    expect(t2.isCompleted, false);
+  });
+}


### PR DESCRIPTION
## Summary
- support tags on tasks and routines
- display and filter by tags in calendar
- fix checkbox toggling logic for tasks and routines
- polish settings page tag management
- add widget test for independent task toggles

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c2fb7be508331a8e37c1d43620cf2